### PR TITLE
Chat Thread Switch Method

### DIFF
--- a/src/easychatgpt/chatgpt.py
+++ b/src/easychatgpt/chatgpt.py
@@ -29,6 +29,7 @@ class ChatClient:
     wait_cq = 'text-2xl'
     reset_xq = '//a[text()="New Chat"]'
     thread_xq = '//*[@class="flex py-3 px-3 items-center gap-3 relative rounded-md hover:bg-[#2A2B32] cursor-pointer break-all hover:pr-4 group"]//*[text()="{}"]' # format with thread name before use
+    thread_selected_xq = '//*[@class="flex py-3 px-3 items-center gap-3 relative rounded-md cursor-pointer break-all pr-14 bg-gray-800 hover:bg-gray-800 group"]//*[text()="{}"]'
 
     def __log(self, msg: str) -> None:
         if self.verbose:

--- a/src/easychatgpt/chatgpt.py
+++ b/src/easychatgpt/chatgpt.py
@@ -9,6 +9,8 @@ from threading import Thread
 
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from selenium.common.exceptions import NoSuchElementException
+
 
 from easychatgpt.exceptions import NotEnoughInformationException, CouldNotSolveCaptcha
 

--- a/src/easychatgpt/chatgpt.py
+++ b/src/easychatgpt/chatgpt.py
@@ -26,6 +26,7 @@ class ChatClient:
     answer_cq = 'group'
     wait_cq = 'text-2xl'
     reset_xq = '//a[text()="New Chat"]'
+    thread_xq = '//*[@class="flex py-3 px-3 items-center gap-3 relative rounded-md hover:bg-[#2A2B32] cursor-pointer break-all hover:pr-4 group"]//*[text()="{}"]' # format with thread name before use
 
     def __log(self, msg : str) -> None:
         if self.verbose:
@@ -172,3 +173,20 @@ class ChatClient:
             print(f"There is no tab with index {idx}")
             return
         self.browser.switch_to.window(windows[idx])
+
+    def switch_thread(self, name):
+        """the thread is switched to the thread that goes by the name specified"""
+        try:
+            self.browser.find_element(By.XPATH, self.thread_xq.format(name)).click()
+            self.__log("Thread {} selected".format(name))
+
+        except NoSuchElementException:
+            try:
+                self.browser.find_element(By.XPATH, self.thread_selected_xq.format(name)).click()
+                self.__log("Thread {} already selected".format(name))
+            except Exception as e:
+                self.__log("An error occurred: Thread could not be found")
+                printStackTrace(e)
+
+        except Exception as e:
+            printStackTrace(e)

--- a/src/easychatgpt/chatgpt.py
+++ b/src/easychatgpt/chatgpt.py
@@ -1,5 +1,6 @@
 import asyncio
 import time
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from typing import List
 
@@ -180,6 +181,7 @@ class ChatClient:
 
     def switch_thread(self, name):
         """the thread is switched to the thread that goes by the name specified"""
+        fail = 0
         try:
             self.browser.find_element(By.XPATH, self.thread_xq.format(name)).click()
             self.__log("Thread {} selected".format(name))
@@ -190,7 +192,15 @@ class ChatClient:
                 self.__log("Thread {} already selected".format(name))
             except Exception as e:
                 self.__log("An error occurred: Thread could not be found")
-                printStackTrace(e)
+                traceback.print_exc()
+                fail = 1
 
         except Exception as e:
-            printStackTrace(e)
+            traceback.print_exc()
+            fail = 1
+
+        else:
+            # selected another thread, lets make sure its usable before we continue
+            chat_box = self.__sleepy_find_element(By.XPATH, self.chatbox_cq)
+
+        return fail


### PR DESCRIPTION
I have added the method `switch_thread(self, name)` that switches the chat thread to the named thread. 

Here's an example of how it might be used:
```python
# the chat threads 'JavaScript', 'Jokes', and 'Backflips' already exist
from easychatgpt import ChatClient
chat = ChatClient(OPENAI_EMAIL, OPENAI_PASSWORD)

chat.switch_thread("JavaScript")
print(chat.interact("How do I make an HTTP request in Javascript?"))

chat.switch_thread("Jokes")
print(chat.interact("Tell me a joke about turtles"))

chat.switch_thread("Backflips")
print(chat.interact("How do I do a backflip?"))
```

These different queries about different topics are now separated into different threads, with different contexts. I can also work on delete, edit, create, etc. functions for threads to go along with this.

Let me know what you think! :)